### PR TITLE
fix application stucking at main.go:127 cReader.Select() 

### DIFF
--- a/lib/mailboxes.go
+++ b/lib/mailboxes.go
@@ -40,12 +40,19 @@ func DetectTrash(cReader *client.Client) (string, error) {
 		done <- cReader.List("", "*", mailboxes)
 	}()
 
+	var trashMailbox = ""
 	for m := range mailboxes {
 		if InStringSlice("\\Trash", m.Attributes) {
 			Log.DebugF("Deleted messages will be moved to \"%s\"", m.Name)
-			return m.Name, nil
+			trashMailbox = m.Name
+			//break
 		}
 	}
-
+	if err := <-done; err != nil {
+		Log.ErrorF("%v\n", err)
+	}
+	if trashMailbox != "" {
+		return trashMailbox, nil
+	}
 	return "", fmt.Errorf("No trash mailbox detected")
 }


### PR DESCRIPTION
when mailbox list was not consumed in `lib/mailboxes.go` function `DetectTrash`  by [leaving the loop](https://github.com/axllent/imap-scrub/blob/aae7ecdc34e2cbf13e5da4ac9310096706739f52/lib/mailboxes.go#L46) with a return, the main app was hanging when trying to request the mailbox in [main.go:127 cReader.Select() ](https://github.com/axllent/imap-scrub/blob/aae7ecdc34e2cbf13e5da4ac9310096706739f52/main.go#L129)

Was really hard to find ;-) for a total Golang novice like me.
Thanks for the great app!
Andreas