### PR TITLE
Feature / new action export_mailbox to mbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist/
 /imap-scrub
 *.yml
+imap-scrub.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /imap-scrub
 *.yml
 imap-scrub.code-workspace
+/saved-emails/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": [
+                "-y",
+                "config.yml"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ rules:
     min_size: 512 
     older_than: 90
     actions: save_attachments, remove_attachments
+  - mailbox: "[Gmail]/All Mail"
+    from: myclient@example.com
+    actions: export_mailbox
 ```
 
 See [All yaml config options](#all-yaml-config-options) below for more info.
@@ -67,7 +70,7 @@ ssl:       true   # use SSL (default true)
 port:      993    # IMAP port number (default 993 if SSL is true, else 143)
 user:      string # IMAP username
 pass:      string # IMAP password
-save_path: string # local directory to save attachments (default current dir)
+save_path: string # local directory to save attachments and mailbox directories (default current dir)
 use_trash: false  # see below
 rules:
   - mailbox:         string # IMAP mailbox name see below)
@@ -103,6 +106,7 @@ There are three possible actions, namely:
 - `save_attachments` will save any attachments to `save_path`
 - `remove_attachments` will remove the all attachments and inline images from the original email 
 - `delete` will simply delete the email
+- `export_mailbox` will create a new `mbox` file per mailbox with all selected emails
 
 The `actions:` config may include a combination of `save_attachments` and one other (comma-separated), eg :`actions: save_attachments, remove_atachments`. 
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/axllent/ghru v1.2.1
 	github.com/emersion/go-imap v1.0.4
 	github.com/emersion/go-imap-move v0.0.0-20190710073258-6e5a51a5b342
+	github.com/emersion/go-mbox v1.0.2 // indirect
 	github.com/emersion/go-message v0.11.1
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/emersion/go-imap v1.0.4 h1:uiCAIHM6Z5Jwkma1zdNDWWXxSCqb+/xHBkHflD7XBr
 github.com/emersion/go-imap v1.0.4/go.mod h1:yKASt+C3ZiDAiCSssxg9caIckWF/JG7ZQTO7GAmvicU=
 github.com/emersion/go-imap-move v0.0.0-20190710073258-6e5a51a5b342 h1:5p1t3e1PomYgLWwEwhwEU5kVBwcyAcVrOpexv8AeZx0=
 github.com/emersion/go-imap-move v0.0.0-20190710073258-6e5a51a5b342/go.mod h1:QuMaZcKFDVI0yCrnAbPLfbwllz1wtOrZH8/vZ5yzp4w=
+github.com/emersion/go-mbox v1.0.2 h1:tE/rT+lEugK9y0myEymCCHnwlZN04hlXPrbKkxRBA5I=
+github.com/emersion/go-mbox v1.0.2/go.mod h1:Yp9IVuuOYLEuMv4yjgDHvhb5mHOcYH6x92Oas3QqEZI=
 github.com/emersion/go-message v0.11.1 h1:0C/S4JIXDTSfXB1vpqdimAYyK4+79fgEAMQ0dSL+Kac=
 github.com/emersion/go-message v0.11.1/go.mod h1:C4jnca5HOTo4bGN9YdqNQM9sITuT3Y0K6bSUw9RklvY=
 github.com/emersion/go-sasl v0.0.0-20191210011802-430746ea8b9b h1:uhWtEWBHgop1rqEk2klKaxPAkVDCXexai6hSuRQ7Nvs=

--- a/lib/config.go
+++ b/lib/config.go
@@ -16,6 +16,7 @@ var (
 		"delete":             true,
 		"save_attachments":   true,
 		"remove_attachments": true,
+		"export_mailbox":     true,
 	}
 )
 
@@ -131,4 +132,9 @@ func (r Rule) RemoveAttachments() bool {
 // SaveAttachments returns whether a rule is set to delete messages
 func (r Rule) SaveAttachments() bool {
 	return strings.Contains(r.Actions, "save_attachments")
+}
+
+// SaveAttachments returns whether a rule is set to delete messages
+func (r Rule) ExportMailbox() bool {
+	return strings.Contains(r.Actions, "export_mailbox")
 }

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/emersion/go-imap"
+	mboxlib "github.com/emersion/go-mbox"
 )
 
 var resultCount = 1
@@ -152,4 +153,35 @@ func SaveAttachment(b []byte, emailAddress, fileName string, timestamp time.Time
 	Log.NoticeF(" - Saved %s/%s (%s)", emailAddress, hashed, ByteCountSI(bytes))
 
 	return nil
+}
+
+func CreateMBOX(mailboxName string) (*mboxlib.Writer, error) {
+	//func CreateMBOX(mailboxName string) (*os.File, error) {
+	var mailboxParts = strings.Split(mailboxName, "/")
+
+	outDir := path.Join(Config.SavePath, path.Join(mailboxParts...))
+	if err := CreateDir(outDir); err != nil {
+		return nil, err
+	}
+
+	outFile := path.Join(outDir, "mbox")
+	if FileExists(outFile) {
+		Log.WarningF(" - File '%s/%s' already exists", outDir, "mbox")
+		return nil, fmt.Errorf("Filename exists")
+	}
+
+	file, err := os.OpenFile(
+		outFile,
+		os.O_WRONLY|os.O_TRUNC|os.O_CREATE,
+		0664,
+	)
+	if err != nil {
+		return nil, err
+	}
+	//defer file.Close()
+
+	mboxWriter := mboxlib.NewWriter(file)
+
+	return mboxWriter, nil
+	//return file, nil
 }


### PR DESCRIPTION
**Use Case**
Backup existing E-Mails including attachments.

- for each mailbox create a folder structure which is based on the IMAP folder structure
- store all per rules selected email including attachments into on file in mbox format
- supports all existing rules
- can be combined with all existing actions: delete, remove_attachment, save_attachments

**roadmap**
- [ ]  append emails to existing mbox files if message id is new - this would allow to resume a download which has been killed by a connection problem
- [ ] define a different folder for the export (currently shared with save_attachments)
- [ ] allow to install with [homebrew](https://brew.sh)
